### PR TITLE
Changes for Android 12 support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Needed only if your app communicates with already-paired Bluetooth
+         devices. Since Android 12. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/bike/hackboy/bronco/view/DeviceListAdapter.java
+++ b/app/src/main/java/bike/hackboy/bronco/view/DeviceListAdapter.java
@@ -3,6 +3,7 @@ package bike.hackboy.bronco.view;
 import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
+import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -44,8 +45,13 @@ public class DeviceListAdapter extends RecyclerView.Adapter<DeviceListAdapter.Vi
 		BluetoothDevice device = data.get(position);
 
 		String name = device.getName();
-		String alias = device.getAlias();
+		String alias = null;
 		String mac = device.getAddress();
+
+        /* min Android API level required is 30 (R) */
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            alias = device.getAlias();
+        }
 
 		holder.name.setText(name);
 		holder.mac.setText(mac);


### PR DESCRIPTION
This adds a new Bluetooth permission introduces in Android 12.
It also fixes another lint warning about `BluetoothDevice.getAlias()` being called, which is only supported as of API level 30 (R), while the minSdkVersion is 23 for this app.